### PR TITLE
Fix timezone error in meetup

### DIFF
--- a/meetup/example.rkt
+++ b/meetup/example.rkt
@@ -1,0 +1,47 @@
+#lang racket
+
+(require math/number-theory
+         racket/date)
+
+(define (leap-year? year)
+  (or (and (divides? 4 year)
+           (not (divides? 100 year)))
+      (divides? 400 year)))
+
+(define (days-in-month year month)
+  (case month
+    [(1 3 5 7 8 10 12) 31]
+    [(4 6 9 11) 30]
+    [(2) (if (leap-year? year) 29 28)]))
+
+(define (make-date year month day)
+  (seconds->date (find-seconds 0 0 0 day month year #f)))
+
+(define (meetup-day year month weekday week)
+  (let ([first-of-week
+          (case week
+            [(first) 1]
+            [(second) 8]
+            [(teenth) 13]
+            [(third) 15]
+            [(fourth) 22]
+            [(last) (- (days-in-month year month) 6)]
+            [else (raise-argument-error 'meetup-day "week" 3 year month weekday week)])]
+        [weekday
+          (case weekday
+            [(Sunday) 0]
+            [(Monday) 1]
+            [(Tuesday) 2]
+            [(Wednesday) 3]
+            [(Thursday) 4]
+            [(Friday) 5]
+            [(Saturday) 6]
+            [else (raise-argument-error 'meetup-day "weekday" 3 year month weekday week)])])
+    (make-date year month
+               (+ first-of-week
+                    (modulo
+                      (- weekday
+                       (date-week-day (make-date year month first-of-week))) 7)
+                 ))))
+
+(provide meetup-day)

--- a/meetup/meetup-test.rkt
+++ b/meetup/meetup-test.rkt
@@ -1,0 +1,23 @@
+#lang racket
+
+(require rackunit
+         rackunit/text-ui
+         racket/date
+         "meetup.rkt")
+
+(define (make-date year month day)
+  (seconds->date (find-seconds 0 0 0 day month year #f)))
+
+(define suite
+  (test-suite
+    "Tests for the meetup exercise"
+    (check-equal? (meetup-day 2013 5 'Monday 'teenth) (make-date 2013 5 13))
+    (check-equal? (meetup-day 2013 2 'Saturday 'teenth) (make-date 2013 2 16))
+    (check-equal? (meetup-day 2013 5 'Tuesday 'first) (make-date 2013 5 7))
+    (check-equal? (meetup-day 2013 4 'Monday 'second) (make-date 2013 4 8))
+    (check-equal? (meetup-day 2013 9 'Thursday 'third) (make-date 2013 9 19))
+    (check-equal? (meetup-day 2013 3 'Sunday 'fourth) (make-date 2013 3 24))
+    (check-equal? (meetup-day 2013 10 'Thursday 'last) (make-date 2013 10 31))
+    (check-equal? (meetup-day 2012 2 'Wednesday 'last) (make-date 2012 2 29))))
+
+(exit (if (zero? (run-tests suite)) 0 1))


### PR DESCRIPTION
Don't merge, since this doesn't fix anything yet.

The meetup test fails when run like this:
```
TZ=America/Chicago bin/check-exercises.sh
```

- [x] fix style (https://github.com/exercism/xracket/pull/5#issuecomment-132736968)
- [ ] make travis fail (https://github.com/exercism/xracket/pull/5#issuecomment-132737618)
- [ ] fix meetup so that travis doesn't fail