### PR TITLE
Remove trailing whitespace

### DIFF
--- a/anagram/anagram-test.rkt
+++ b/anagram/anagram-test.rkt
@@ -8,35 +8,35 @@
 (define anagram-tests
   (test-suite
    "anagram tests"
-   
+
    (test-equal? "no-matches"
                 (anagrams-for "diaper" '("hello" "world" "zombies" "pants"))
                 '())
-   
+
    (test-equal? "detect simple anagram"
                 (anagrams-for "ant" '("tan" "stand" "at"))
                 '("tan"))
-   
+
    (test-equal? "does not confuse different duplicates"
                 (anagrams-for "galea" '("eagle"))
                 '())
-   
+
    (test-equal? "eliminate anagram subsets"
                 (anagrams-for "good" '("dog" "goody"))
                 '())
-   
+
    (test-equal? "detect anagram"
                 (anagrams-for "listen"'("enlists" "google" "inlets" "banana"))
                 '("inlets"))
-   
+
    (test-equal? "multiple-anagrams"
                 (anagrams-for "allergy" '("gallery" "ballerina" "regally" "clergy" "largely" "leading"))
                 '("gallery" "regally" "largely"))
-   
+
    (test-equal? "case-insensitive-anagrams"
                 (anagrams-for "Orchestra" '("cashregister" "Carthorse" "radishes"))
                 '("Carthorse"))
-   
+
    (test-equal? "word is not own anagram"
                 (anagrams-for "banana"'("banana"))
                 '())))

--- a/bob/bob-test.rkt
+++ b/bob/bob-test.rkt
@@ -7,59 +7,59 @@
 (define bob-tests
   (test-suite
    "bob tests"
-   
+
    (test-equal? "responds to something"
                 (response-for "To-may-to, tom-aaaah-to.")
                 "Whatever.")
-   
+
    (test-equal? "responds to shouts"
                 (response-for "WATCH OUT!")
                 "Whoa, chill out!")
-   
+
    (test-equal? "responds to questions"
                 (response-for "Does this cryogenic chamber make me look fat?")
                 "Sure.")
-   
+
    (test-equal? "responds to forceful talking"
                 (response-for "Let's go make out behind the gym!")
                 "Whatever.")
-   
+
    (test-equal? "responds to acronyms"
                 (response-for "It's OK if you don't want to go to the DMV.")
                 "Whatever.")
-   
+
    (test-equal? "responds to forceful questions"
                 (response-for "WHAT THE HELL WERE YOU THINKING?")
                 "Whoa, chill out!")
-   
+
    (test-equal? "responds to shouting with special characters"
                 (response-for "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!")
                 "Whoa, chill out!")
-   
+
    (test-equal? "responds to shouting numbers"
                 (response-for "1, 2 ,3, GO!")
                 "Whoa, chill out!")
-   
+
    (test-equal? "responds to shouting wit no exclamation mark"
                 (response-for "I HATE YOU")
                 "Whoa, chill out!")
-   
+
    (test-equal? "responds to statement containing question mark"
                 (response-for "Ending with ? means a question.")
                 "Whatever.")
-   
+
    (test-equal? "responds to silence"
                 (response-for "")
                 "Fine. Be that way!")
-   
+
    (test-equal? "responds to prolonged-silence"
                 (response-for "     ")
                 "Fine. Be that way!")
-   
+
    (test-equal? "responds to only-numbers"
                 (response-for "1, 2, 3")
                 "Whatever.")
-   
+
    (test-equal? "responds to number-question"
                 (response-for "4?")
                 "Sure.")))

--- a/difference-of-squares/difference-of-squares-test.rkt
+++ b/difference-of-squares/difference-of-squares-test.rkt
@@ -7,14 +7,14 @@
 (define difference-of-squares
   (test-suite
    "difference of squares"
-   
-   (test-eqv? "square-of-sums-to-5" (square-of-sums 5) 225)      
+
+   (test-eqv? "square-of-sums-to-5" (square-of-sums 5) 225)
    (test-eqv? "sum-of-squares-to-5" (sum-of-squares 5) 55)
    (test-eqv? "difference of-sums-to-5" (difference 5) 170)
-   (test-eqv? "square-of-sums-to-10" (square-of-sums 10) 3025)   
-   (test-eqv? "sum-of-squares-to-10"  (sum-of-squares 10) 385)    
-   (test-eqv? "difference of-sums-to-10" (difference 10) 2640)     
-   (test-eqv? "square-of-sums-to-100" (square-of-sums 100) 25502500)      
+   (test-eqv? "square-of-sums-to-10" (square-of-sums 10) 3025)
+   (test-eqv? "sum-of-squares-to-10"  (sum-of-squares 10) 385)
+   (test-eqv? "difference of-sums-to-10" (difference 10) 2640)
+   (test-eqv? "square-of-sums-to-100" (square-of-sums 100) 25502500)
    (test-eqv? "sum-of-squares-to-100" (sum-of-squares 100) 338350)
    (test-eqv? "difference of-sums-to-100" (difference 100) 25164150)))
 

--- a/grains/grains-test.rkt
+++ b/grains/grains-test.rkt
@@ -7,7 +7,7 @@
 (define grains-tests
   (test-suite
    "grains tests"
-   
+
    (test-eqv? "square 1" (square 1) 1)
    (test-eqv? "square 2" (square 2) 2)
    (test-eqv? "square 3" (square 3) 4)

--- a/hello-world/hello-world-test.rkt
+++ b/hello-world/hello-world-test.rkt
@@ -7,7 +7,7 @@
 (define hello-tests
   (test-suite
     "hello world tests"
-    
+
     (test-equal? "no arg returns Hello, World!" (hello) "Hello, World!")
     (test-equal? "with arg returns Hello, arg!" (hello "exercism") "Hello, exercism!")))
 

--- a/leap/leap-test.rkt
+++ b/leap/leap-test.rkt
@@ -7,7 +7,7 @@
 (define leap-tests
   (test-suite
    "leap tests"
-   
+
    (test-eqv? "vanilla-leap-year" (leap-year? 1996) #t)
    (test-eqv? "any-old-year" (leap-year? 1997)#f)
    (test-eqv? "non-leap-even-year" (leap-year? 1998) #f)

--- a/list-ops/list-ops-test.rkt
+++ b/list-ops/list-ops-test.rkt
@@ -9,104 +9,104 @@
 (define list-ops-tests
   (test-suite
    "list operations tests"
-   
+
    (test-eqv? "length of empty list"
               (my-length '())
               0)
-   
+
    (test-eqv? "length of normal list"
               (my-length '(1 3 5 7))
               4)
-   
+
    (test-eqv? "length of huge list"
               (my-length (build-list 1000000 values))
               1000000)
-   
+
    (test-equal? "reverse of empty list"
                 (my-reverse '())
                 '())
-   
+
    (test-equal? "reverse of normal list"
                 (my-reverse '(1 3 5 7))
                 '(7 5 3 1))
-   
+
    (test-equal? "reverse of huge list"
                 (my-reverse (build-list 1000000 values))
                 (build-list 1000000 (lambda (x) (- 999999 x))))
-   
+
    (test-equal? "map of empty list"
                 (my-map inc '())
                 '())
-   
+
    (test-equal? "map of normal list"
                 (my-map inc '(1 2 3 4))
                 '(2 3 4 5))
-   
+
    (test-equal? "map of huge list"
                 (my-map inc (build-list 1000000 values))
                 (build-list 1000000 (lambda (x) (+ x 1))))
-   
+
    (test-equal? "filter of empty list"
                 (my-filter odd? '())
                 '())
-   
+
    (test-equal? "filter of normal list"
                 (my-filter odd? '(1 2 3 4))
                 '(1 3))
-   
+
    (test-equal? "filter of huge list"
                 (my-filter odd? (build-list 1000000 values))
                 (filter odd? (build-list 1000000 values)))
-   
+
    (test-eqv? "fold of empty list"
               (my-fold + 0 '())
               0)
-   
+
    (test-eqv? "fold of normal list"
               (my-fold + -3 '(1 2 3 4))
               7)
-   
+
    (test-eqv? "fold of huge list"
               (my-fold + 0 (build-list 1000000 values))
               (foldl + 0 (build-list 1000000 values)))
-   
+
    (test-eqv? "fold with non-commutative function"
               (my-fold (lambda (x acc) (- acc x)) 10 '(1 2 3 4))
               0)
-   
+
    (test-equal? "append of empty lists"
                 (my-append '() '())
                 '())
-   
+
    (test-equal? "append of empty and non-empty list"
                 (my-append '() '(1 2 3 4))
                 '(1 2 3 4))
-   
+
    (test-equal? "append of non-empty and empty list"
                 (my-append '(1 2 3 4) '())
                 '(1 2 3 4))
-   
+
    (test-equal? "append of non-empty lists"
                 (my-append '(1 2 3) '(4 5))
                 '(1 2 3 4 5))
-   
+
    (test-equal? "append of huge lists"
                 (my-append (build-list 1000000 values)
                            (build-list 1000000 (lambda (x) (+ x 1000000))))
                 (build-list 2000000 values))
-   
+
    (test-equal? "concatenate of empty list of lists"
                 (my-concatenate '())
                 '())
-   
+
    (test-equal? "concatenate of normal list of lists"
                 (my-concatenate '((1 2) (3) () (4 5 6)))
                 '(1 2 3 4 5 6))
-   
+
    (test-equal? "concatenate of huge list of small lists"
                 (my-concatenate (build-list 1000000 list))
                 (build-list 1000000 values))
-   
+
    (test-equal? "concatenate of small list of huge lists"
                 (my-concatenate
                  (build-list 10 (lambda (i)

--- a/nucleotide-count/nucleotide-count-test.rkt
+++ b/nucleotide-count/nucleotide-count-test.rkt
@@ -7,20 +7,20 @@
 (define nucleotide-count-tests
   (test-suite
    "nucleotide count tests"
-   
+
    (test-equal? "empty dna strand has no nucleotides"
                 (nucleotide-counts "")
                 '((#\A . 0) (#\C . 0) (#\G . 0) (#\T . 0)))
-   
+
    (test-equal? "repetitive sequence has only guanine"
                 (nucleotide-counts "GGGGGGGG")
                 '((#\A . 0) (#\C . 0) (#\G . 8) (#\T . 0)))
-   
+
    (test-equal? "counts all nucleotides"
                 (nucleotide-counts
                  "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC")
                 '((#\A . 20) (#\C . 12) (#\G . 17) (#\T . 21)))
-   
+
    (test-exn "invalid nucleotide" exn:fail? (lambda () (nucleotide-counts "AGGTCCXGA")))))
 
 (run-tests nucleotide-count-tests)

--- a/perfect-numbers/perfect-numbers-test.rkt
+++ b/perfect-numbers/perfect-numbers-test.rkt
@@ -19,7 +19,7 @@
    (test-equal? "return 3 perfect numbers for range 1 - 1000"
               (perfect-numbers 1000)
               '(6 28 496))
-   
+
    (test-equal? "return 4 perfect numbers for range 1 - 10000"
               (perfect-numbers 10000)
               '(6 28 496 8128))))

--- a/phone-number/phone-number-test.rkt
+++ b/phone-number/phone-number-test.rkt
@@ -7,7 +7,7 @@
 (define phone-number-tests
   (test-suite
    "phone number tests"
-   
+
    (test-equal? "cleans number" (numbers "(123) 456-7890") "1234567890")
    (test-equal? "cleans numbers with dots" (numbers "123.456.7890") "1234567890")
    (test-equal? "valid when 11 digits and first is 1" (numbers "11234567890") "1234567890")

--- a/point-mutations/point-mutations-test.rkt
+++ b/point-mutations/point-mutations-test.rkt
@@ -7,27 +7,27 @@
 (define point-mutations-tests
   (test-suite
    "point mutations tests"
-   
+
    (test-eqv? "no difference between empty strands"
               (hamming-distance "" "")
               0)
-   
+
    (test-eqv? "no difference between identical strands"
               (hamming-distance "GATTACA" "GATTACA")
               0)
-   
+
    (test-eqv? "complete hamming distance in small strand"
               (hamming-distance "ACT" "GGA")
               3)
-   
+
    (test-eqv? "small hamming distance in middle somewhere"
               (hamming-distance "GGACG" "GGTCG")
               1)
-   
+
    (test-eqv? "larger difference"
               (hamming-distance "ACCAGGG" "ACTATGG")
               2)
-   
+
    (test-exn "String length mismatch." exn:fail?
              (lambda ()
                (hamming-distance "AGACAACAGCCAGCCGCCGGATT" "AGGCAA")))))

--- a/raindrops/raindrops-test.rkt
+++ b/raindrops/raindrops-test.rkt
@@ -7,7 +7,7 @@
 (define raindrops-tests
   (test-suite
    "raindrops tests"
-   
+
    (test-equal? "test-1" (convert 1) "1")
    (test-equal? "test-3" (convert 3) "Pling")
    (test-equal? "test-5" (convert 5) "Plang")

--- a/rna-transcription/rna-transcription-test.rkt
+++ b/rna-transcription/rna-transcription-test.rkt
@@ -7,7 +7,7 @@
 (define rna-transcription-tests
   (test-suite
    "RNA transcription tests"
-   
+
    (test-equal? "transcribes cytosine to guanine" (to-rna "C") "G")
    (test-equal? "transcribes guanine to cytosine" (to-rna "G") "C")
    (test-equal? "transcribes adenine to uracil" (to-rna "A") "U")


### PR DESCRIPTION
Some editors are set to highlight trailing whitespace as an error.