### PR TITLE
Racket-y style

### DIFF
--- a/anagram/anagram-test.rkt
+++ b/anagram/anagram-test.rkt
@@ -1,44 +1,50 @@
 #lang racket/base
 
-(require rackunit)
-(require rackunit/text-ui)
-(require "anagram.rkt")
+;; pick one of: 
+(require "example.rkt")
+; (require "anagram.rkt")
 
+(module+ test
+  (require rackunit rackunit/text-ui))
 
-(define suite
-  (test-suite
-   "anagram tests"
+(module+ test
+  (define allergies '("gallery" "ballerina" "regally" "clergy" "largely" "leading"))
 
-   (test-equal? "no-matches"
-                (anagrams-for "diaper" '("hello" "world" "zombies" "pants"))
-                '())
+  (define suite
+    (test-suite
+     "anagram tests"
+     
+     (test-equal? "no-matches"
+                  (anagrams-for "diaper" '("hello" "world" "zombies" "pants"))
+                  '())
+     
+     (test-equal? "detect simple anagram"
+                  (anagrams-for "ant" '("tan" "stand" "at"))
+                  '("tan"))
+     
+     (test-equal? "does not confuse different duplicates"
+                  (anagrams-for "galea" '("eagle"))
+                  '())
+     
+     (test-equal? "eliminate anagram subsets"
+                  (anagrams-for "good" '("dog" "goody"))
+                  '())
+     
+     (test-equal? "detect anagram"
+                  (anagrams-for "listen"'("enlists" "google" "inlets" "banana"))
+                  '("inlets"))
+     
+     (test-equal? "multiple-anagrams"
+                  (anagrams-for "allergy" allergies)
+                  '("gallery" "regally" "largely"))
+     
+     (test-equal? "case-insensitive-anagrams"
+                  (anagrams-for "Orchestra" '("cashregister" "Carthorse" "radishes"))
+                  '("Carthorse"))
+     
+     (test-equal? "word is not own anagram"
+                  (anagrams-for "banana"'("banana"))
+                  '())))
 
-   (test-equal? "detect simple anagram"
-                (anagrams-for "ant" '("tan" "stand" "at"))
-                '("tan"))
-
-   (test-equal? "does not confuse different duplicates"
-                (anagrams-for "galea" '("eagle"))
-                '())
-
-   (test-equal? "eliminate anagram subsets"
-                (anagrams-for "good" '("dog" "goody"))
-                '())
-
-   (test-equal? "detect anagram"
-                (anagrams-for "listen"'("enlists" "google" "inlets" "banana"))
-                '("inlets"))
-
-   (test-equal? "multiple-anagrams"
-                (anagrams-for "allergy" '("gallery" "ballerina" "regally" "clergy" "largely" "leading"))
-                '("gallery" "regally" "largely"))
-
-   (test-equal? "case-insensitive-anagrams"
-                (anagrams-for "Orchestra" '("cashregister" "Carthorse" "radishes"))
-                '("Carthorse"))
-
-   (test-equal? "word is not own anagram"
-                (anagrams-for "banana"'("banana"))
-                '())))
-
-(exit (if (zero? (run-tests suite)) 0 1))
+  ;; why exit? 
+  (exit (if (zero? (run-tests suite)) 0 1)))

--- a/anagram/example.rkt
+++ b/anagram/example.rkt
@@ -1,15 +1,20 @@
 #lang racket
 
-(provide anagrams-for)
+(provide
+ ;; String [Listof String] -> [Listof String]
+ ;; pick candidates for anagrams from the given list
+ ;; def. a candidate consists of the same letters as subject
+ anagrams-for)
 
+;; -----------------------------------------------------------------------------
 (define (anagrams-for subject candidates)
   (filter (lambda (w) (anagram? w subject)) candidates))
 
+;; String String -> Boolean
+;; is a an anagram for b?
 (define (anagram? a b)
-  (let ([sorted-string
-         (lambda (s)
-           (apply string (sort (string->list s) char-ci<?)))])
-    (and
-     (string-ci=? (sorted-string a)
-                  (sorted-string b))
-     (not (string-ci=? a b)))))
+  (define (sorted-string s)
+    (list->string (sort (string->list s) char-ci<?)))
+  (and
+   (string-ci=? (sorted-string a) (sorted-string b))
+   (not (string-ci=? a b))))


### PR DESCRIPTION
The Racket style calls for reasonable documentation. Exported functions are ideally 
documented in the provide specification. 

Tests go into submodules named tests. race test can run these submodules from 
the command line.  They are also run automatically when programmers develop from 
within DrRacket. 

NOTE: I have left the (exit ..) call in for now but I consider it completely superfluous. 
I don't know the context of how you will run/use these example and test files, but I 
urge you to check out the raco test command. 