### PR TITLE
[say] fix example.rkt upper bound

### DIFF
--- a/say/example.rkt
+++ b/say/example.rkt
@@ -93,14 +93,14 @@
         (cond
          [(zero? n)
           ""]
-         [(= 100 n)
-          "one hundred"]
-         [(< 100 n)
+         [(< n 100)
+          (step1 r)]
+         [else
           (define hd (vector-ref N<20 q))
           (define tl (step1 r))
-          (string-append hd " hundred " tl)]
-         [else
-          (step1 r)]))
+          (if (equal? "zero" tl)
+              (string-append hd " hundred")
+              (string-append hd " hundred " tl))]))
       ;; Don't print a scale for zeros or the last chunk
       (if (or (eq? s 'END) (zero? n))
           n-str

--- a/say/example.rkt
+++ b/say/example.rkt
@@ -11,11 +11,11 @@
   (only-in racket/match match-define)
   (only-in racket/string string-trim))
 
-(define UPPER-BOUND 1000000000000000)
-;; The largest printable number
-
 (define SCALE '#(END thousand million billion trillion))
 ;; Supported size classifiers
+
+(define UPPER-BOUND (sub1 (expt 10 (* (vector-length SCALE) 3))))
+;; The largest printable number
 
 (define (scale? v) (for/or ([s (in-vector SCALE)]) (eq? v s)))
 ;; Contract for scales

--- a/say/say-test.rkt
+++ b/say/say-test.rkt
@@ -59,6 +59,8 @@
          [999000000000000 == "nine hundred ninety-nine trillion"]
          [0 == "zero"]
          [16 == "sixteen"]
+         [300 == "three hundred"]
+         [440 == "four hundred forty"]
          [999 == "nine hundred ninety-nine"]
          [-1 == "negative one"]
          [22 == "twenty-two"]
@@ -67,6 +69,7 @@
          [14 == "fourteen"]
          [50 == "fifty"]
          [98 == "ninety-eight"]
+         [-432600 == "negative four hundred thirty-two thousand six hundred"]
          [12345 == "twelve thousand three hundred forty-five"]))))
 
   (for ([suite (in-list step*)])


### PR DESCRIPTION
Because the integer-in contract includes its bounds.
Also, made UPPER-BOUND a computed constant.