### PR TITLE
Fix unbalanced parentheses

### DIFF
--- a/accumulate/accumulate-test.rkt
+++ b/accumulate/accumulate-test.rkt
@@ -29,7 +29,7 @@
      
      (test-equal? "reverse strings"                
                   (accumulate (list "the" "quick" "brown" "fox" "jumped" "over" "the" "lazy" "dog") reverse-words)
-                  (map reverse-words '("the" "quick" "brown" "fox" "jumped" "over" "the" "lazy" "dog")))
+                  (map reverse-words '("the" "quick" "brown" "fox" "jumped" "over" "the" "lazy" "dog")))))
      
      
-     (run-tests suite))))
+     (run-tests suite))


### PR DESCRIPTION
Or the run of the test will not show anything (run-rests should be
part of the test module, not of the test-suite).