### PR TITLE
Update installation instructions for OS X

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,7 +2,7 @@ Please reference Racket's [Getting Started](http://docs.racket-lang.org/getting-
 
 Alternative installation options and further notes for specific OSes follow.
 
-## OS X
+## macOS
 
 Install via Homebrew:
 
@@ -10,15 +10,15 @@ Install via Homebrew:
 brew update
 brew install minimal-racket
 ```
-The `minimal-racket` package will probably wor for solving the problems, but it does not include the graphical interface IDE, DrRacket. If you want that, you have to install the full racket distribution from cask:
+The `minimal-racket` package will probably work for solving the problems, but it does not include the graphical interface IDE, DrRacket. If you want that, you have to install the full racket distribution from cask:
 
 ```
 brew tap caskroom/cask
 brew install racket
 ```
 
-### Note on using the official installer on OS X
-Note that on OS X, the official installer puts the files under `/Applications`, and as a result the `racket` and `raco` executables are not accessible on command-line terminals. You have to add the `bin` subdirectory below the Racket installation location (e.g., `/Applications/Racket v6.8/bin` for version 6.8) to the `$PATH`.  
+### macOS official installer
+Note that on macOS, the official installer puts the files under `/Applications`, and as a result the `racket` and `raco` executables are not accessible on command-line terminals. You have to add the `bin` subdirectory below the Racket installation location (e.g., `/Applications/Racket v6.8/bin` for version 6.8) to the `$PATH`.  
 
 
 ## Linux

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,17 +1,27 @@
 Please reference Racket's [Getting Started](http://docs.racket-lang.org/getting-started/) page for instructions on downloading and installing Racket.
 
-For *nix variants, you can also install Racket using your OS' package manager:
+Alternative installation options and further notes for specific OSes follow.
 
-**OS X**
+## OS X
 
 Install via Homebrew:
 
 ```
 brew update
+brew install minimal-racket
+```
+The `minimal-racket` package will probably wor for solving the problems, but it does not include the graphical interface IDE, DrRacket. If you want that, you have to install the full racket distribution from cask:
+
+```
+brew tap caskroom/cask
 brew install racket
 ```
 
-**Linux**
+### Note on using the official installer on OS X
+Note that on OS X, the official installer puts the files under `/Applications`, and as a result the `racket` and `raco` executables are not accessible on command-line terminals. You have to add the `bin` subdirectory below the Racket installation location (e.g., `/Applications/Racket v6.8/bin` for version 6.8) to the `$PATH`.  
+
+
+## Linux
 
 Debian:
 ```


### PR DESCRIPTION
- Currently homebrew does not included a full "racket" package, only minimal-racket. The full package is available via cask
- Add a note for users of the official installer to enable the CLI tools (needed to follow the instructions on how to run tests)