### PR TITLE
Add acronym exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -111,6 +111,11 @@
       "difficulty": 1,
       "slug": "list-ops",
       "topics": []
+    },
+    {
+      "difficulty": 1,
+      "slug": "acronym",
+      "topics": []
     }
   ],
   "deprecated": [

--- a/exercises/acronym/acronym-test.rkt
+++ b/exercises/acronym/acronym-test.rkt
@@ -1,0 +1,40 @@
+#lang racket/base
+
+(require "acronym.rkt")
+
+(module+ test
+  (require rackunit rackunit/text-ui)
+
+  (define suite
+    (test-suite
+     "acronym tests"
+
+     (test-equal? "basic"
+                  (acronym "Portable Network Graphics")
+                  "PNG")
+
+     (test-equal? "lowercase words"
+                  (acronym "Ruby on Rails")
+                  "ROR")
+
+     (test-equal? "camelcase"
+                  (acronym "HyperText Markup Language")
+                  "HTML")
+
+     (test-equal? "punctuation"
+                  (acronym "First In, First Out")
+                  "FIFO")
+
+     (test-equal? "all caps words"
+                  (acronym "PHP: Hypertext Preprocessor")
+                  "PHP")
+
+     (test-equal? "non-acronym all caps word"
+                  (acronym "GNU Image Manipulation Program")
+                  "GIMP")
+
+     (test-equal? "hyphenated"
+                  (acronym "Complementary metal-oxide semiconductor")
+                  "CMOS")))
+
+  (run-tests suite))

--- a/exercises/acronym/acronym.rkt
+++ b/exercises/acronym/acronym.rkt
@@ -1,0 +1,3 @@
+#lang racket
+
+(provide acronym)

--- a/exercises/acronym/example.rkt
+++ b/exercises/acronym/example.rkt
@@ -1,0 +1,25 @@
+#lang racket
+
+(provide acronym)
+
+(define (all-upper-case? s)
+  (equal? s (string-upcase s)))
+
+(define (all-lower-case? s)
+  (equal? s (string-downcase s)))
+
+(define (process-word word)
+  (define (first-letter s)
+    (~a (char-upcase (string-ref s 0))))
+  (define (filter-caps s)
+    (list->string (filter char-upper-case? (string->list s))))
+  (cond
+    [(all-upper-case? word) (first-letter word)]
+    [(all-lower-case? word) (first-letter word)]
+    [else (filter-caps word)]))  ;; camelcase/mixed case
+
+(define (acronym str)
+  (let ([words (string-split str #px"(\\s+)|-")])
+    (apply string-append
+           (for/list ([w (in-list words)])
+             (process-word w)))))


### PR DESCRIPTION
This patch adds the acronym exercise with stub, tests and an example solution, as per the guidelines. The tests were based on the x-common test data. 